### PR TITLE
Switch to Cuckoo REST API

### DIFF
--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -219,6 +219,8 @@
       with_items:
         - peekaboo.service
         - cuckoohttpd.service
+        - cuckooapi.service
+        - cuckoosandbox.service
         - mysql-proxy.service
         - mysql-proxy.socket
 
@@ -229,6 +231,7 @@
       with_items:
         - peekaboo
         - cuckoohttpd
+        - cuckoosandbox
 
     - name: Place Peekaboo config in /opt/peekaboo
       tags: peekabooconf

--- a/systemd/cuckooapi.service
+++ b/systemd/cuckooapi.service
@@ -1,0 +1,18 @@
+# install as /etc/systemd/system/cuckooapi.service
+
+[Unit]
+Description=Cuckoo REST API
+After=network.target
+
+[Service]
+User=peekaboo
+Group=peekaboo
+WorkingDirectory=/var/lib/peekaboo
+ExecStart=/opt/cuckoo/bin/cuckoo api
+KillMode=control-group
+Restart=on-failure
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+Alias=cuckoo-api.service

--- a/systemd/cuckoohttpd.service
+++ b/systemd/cuckoohttpd.service
@@ -8,7 +8,7 @@ After=network.target
 User=peekaboo
 Group=peekaboo
 WorkingDirectory=/var/lib/peekaboo
-ExecStart=/opt/cuckoo/bin/cuckoo web -H 0.0.0.0 -p 8000
+ExecStart=/opt/cuckoo/bin/cuckoo web
 KillMode=control-group
 Restart=on-failure
 Type=simple
@@ -16,5 +16,3 @@ Type=simple
 [Install]
 WantedBy=multi-user.target
 Alias=cuckoo-http.service
-
-

--- a/systemd/cuckoosandbox.service
+++ b/systemd/cuckoosandbox.service
@@ -1,0 +1,18 @@
+# install as /etc/systemd/system/cuckooapi.service
+
+[Unit]
+Description=Cuckoo Sandbox
+After=network.target
+
+[Service]
+User=peekaboo
+Group=peekaboo
+WorkingDirectory=/var/lib/peekaboo
+ExecStart=/opt/cuckoo/bin/cuckoo
+KillMode=control-group
+Restart=on-failure
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+Alias=cuckoo-sandbox.service

--- a/systemd/peekaboo.service
+++ b/systemd/peekaboo.service
@@ -8,7 +8,8 @@
 
 [Unit]
 Description=Peekaboo Extended Email Attachment Behavior Observation Owl
-After=network.target
+After=network.target cuckooapi.service
+Requires=cuckooapi.service
 
 [Service]
 User=peekaboo

--- a/utils/peekabooStatus.sh
+++ b/utils/peekabooStatus.sh
@@ -11,7 +11,8 @@ uname -a
 echo
 
 blue "Status of systemd units"
-for t in amavis peekaboo cuckoohttpd mongodb postfix fetchmail grafana-server prometheus node_exporter
+for t in amavis peekaboo cuckoohttpd cuckooapi cuckoosandbox \
+	mongodb postfix fetchmail grafana-server prometheus node_exporter
 do
   echo -n $t
   systemctl status $t | grep "\($t.service \|Active:\)"


### PR DESCRIPTION
The installer installs a peekaboo.conf which enables Cuckoo REST API mode. This PR adds the necessary infrastructure for this to actually work OOB.