### PR TITLE
Restore processor wrapper for embed mode

### DIFF
--- a/peekaboo/peekaboo.conf
+++ b/peekaboo/peekaboo.conf
@@ -60,7 +60,7 @@ url            :    mysql+mysqldb://peekaboo:{{ peekaboo_db_password }}@{{ maria
 mode             :    api
 
 # embed mode
-exec             :    /opt/cuckoo/bin/cuckoo
+exec             :    /opt/peekaboo/bin/cuckooprocessor.sh
 submit           :    /opt/cuckoo/bin/cuckoo submit
 
 # api mode


### PR DESCRIPTION
Commit f198c4da replaced the cuckoo processor wrapper for embed mode
with the actual cuckoo executable. This being executed with interpreter
/bin/bash fails to start. This change restores the processor wrapper to
make embed mode functional again.