### PR TITLE
remove timestamp from logging

### DIFF
--- a/peekaboo/peekaboo.conf
+++ b/peekaboo/peekaboo.conf
@@ -33,10 +33,10 @@ score_threshold  :    100
 # log_level
 # possible values: CRITICAL | ERROR | WARNING | INFO | DEBUG
 log_level        :    DEBUG
-# note that any % must be escaped with another %.
-log_format       :    %%(asctime)s - %%(name)s - (%%(threadName)s) - %%(levelname)s - %%(message)s
-# if you use systemd you don't want the timestamp
-# log_format       :    %%(name)s - (%%(threadName)s) - %%(levelname)s - %%(message)s
+# note that any % must be escaped with another %. If you don't use systemd you should include the timestamp
+# log_format       :    %%(asctime)s - %%(name)s - (%%(threadName)s) - %%(levelname)s - %%(message)s
+# if you use systemd you don't need the timestamp since there is already one
+log_format       :    %%(name)s - (%%(threadName)s) - %%(levelname)s - %%(message)s
 
 
 #


### PR DESCRIPTION
Since the default behavior of the installer is also installing systemd service unit and logging to journalctl, I think the timestamp should be removed

```Nov 17 09:56:14 peekaboo peekaboo[3861]: 2018-11-17 09:56:14,955 - peekaboo.toolbox.sampletools - (MainThread) - DEBUG - Searching for a sample with job ID 17```