### PR TITLE
Fix peekaboo.conf owner

### DIFF
--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -238,8 +238,8 @@
       template:
         src: peekaboo/peekaboo.conf 
         dest: /opt/peekaboo/etc/
-        owner: root
-        group: root
+        owner: peekaboo
+        group: peekaboo
         mode: 0600
         backup: true
 


### PR DESCRIPTION
A rebase merge error left peekaboo.conf owned by root but readable only
by the owner. Change ownership to peekaboo as was intended and is
necessary.