### PR TITLE
Install and upgrade Peekaboo using pip

### DIFF
--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -138,12 +138,6 @@
           - mysql
         virtualenv: /opt/cuckoo
         virtualenv_python: python2.7
-    - name: Install Peekaboo dependencies
-      pip:
-        chdir: PeekabooAV
-        requirements: requirements.txt
-        virtualenv: /opt/peekaboo
-        virtualenv_python: python2.7
     - name: Install Peekaboo optional components
       pip:
         name:
@@ -200,13 +194,12 @@
   become: true
   tasks:
     - name: Install Peekaboo
-      command: /opt/peekaboo/bin/python setup.py install
-      args:
+      pip:
         chdir: PeekabooAV
-        creates: /opt/peekaboo/bin/peekaboo
-#      pip:
-#        name: peekabooav
-#        state: present
+        name: .
+        state: latest
+        virtualenv: /opt/peekaboo
+        virtualenv_python: python2.7
 
     - name: Copy systemd unit files to /etc
       copy:


### PR DESCRIPTION
The pip module of ansible can be told to install the lastest version of
Peekaboo using "state: latest".

Since we want to install the version provided by our submodule, we have
to "trick" pip into installing from there by changing into it and
installing ".", i.e. from the current local directory.

Incidentally, pip will also install all dependencies named in
requirements.txt so that the separate dependency installation further up
in the playbook becomes redundant.

Closes #25.