### PR TITLE
Restrict peekaboo access to config file to reading only

### DIFF
--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -655,12 +655,17 @@
 
 # As long as we still need access to files created by amavis. Once we receive
 # them via a rest api between amavis and peekaboo we no longer need to be in
-# group amavis and this section can be moved back to the peekaboo play.
-- name: Restart Peekaboo
+# group amavis and peekaboo service start can be moved back to the peekaboo
+# play.
+- name: Allow access to files and sockets for amavis and peekaboo
   hosts: peekabooav_server
   gather_facts: no
   become: true
   tasks:
+    - name: Add secondary group amavis to user peekaboo
+      user:
+        name: peekaboo
+        groups: amavis
     - name: Start Peekaboo
       systemd:
         name: peekaboo
@@ -731,17 +736,6 @@
         group: root
         mode: 0755
         backup: true
-
-
-- name: Allow access to files and sockets for amavis and peekaboo
-  hosts: peekabooav_server
-  gather_facts: no
-  become: true
-  tasks:
-    - name: Add secondary group amavis to user peekaboo
-      user:
-        name: peekaboo
-        groups: amavis
 
 
 - name: Clean up installer directory

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -550,9 +550,9 @@
       template:
         src: peekaboo/peekaboo.conf
         dest: /opt/peekaboo/etc/peekaboo.conf
-        owner: peekaboo
+        owner: root
         group: peekaboo
-        mode: 0600
+        mode: 0640
         backup: true
 
     - name: Check if an old Peekaboo ruleset.conf exists in /opt/peekaboo

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -666,6 +666,7 @@
       user:
         name: peekaboo
         groups: amavis
+        append: true
     - name: Start Peekaboo
       systemd:
         name: peekaboo

--- a/peekaboo/peekaboo.conf
+++ b/peekaboo/peekaboo.conf
@@ -9,6 +9,9 @@
 # specific group to drop privileges to if not primary group of user
 #group            :    <empty>
 #socket_file      :    /var/run/peekaboo/peekaboo.sock
+# change socket group and mode to open up client access
+socket_group     :    amavis
+#socket_mode      :    0660
 #pid_file         :    /var/run/peekaboo/peekaboo.pid
 #interpreter      :    /usr/bin/python2 -u
 # alternatvely, if using cuckooprocessor.sh as exec below:

--- a/peekaboo/peekaboo.conf
+++ b/peekaboo/peekaboo.conf
@@ -6,7 +6,8 @@
 
 [global]
 #user             :    peekaboo
-group            :    amavis
+# specific group to drop privileges to if not primary group of user
+#group            :    <empty>
 #socket_file      :    /var/run/peekaboo/peekaboo.sock
 #pid_file         :    /var/run/peekaboo/peekaboo.pid
 #interpreter      :    /usr/bin/python2 -u
@@ -82,6 +83,21 @@ url             :    mysql+mysqldb://peekaboo:{{ peekaboo_db_password }}@{{ mari
 # api mode
 #url              :    http://127.0.0.1:8090
 #poll_interval    :    5
+
+# Submit samples with their original filenames if available. Enhances
+# authenticity of analysis environment but also leaks original filenames into
+# Cuckoo's database.
+#submit_original_filename : yes
+
+# Specify how long to track running Cuckoo jobs before giving up on them. This
+# does not actively cancel jobs. It's rather meant to handle cases where jobs
+# have for some reason been dropped by or got stuck within Cuckoo. This value
+# is unrelated to how long our client is willing to wait for a result because
+# even if it gives up on us we would normally want to learn and cache the job
+# result because the analysis was expensive and the sample might be presented
+# to us again.
+#maximum_job_age : 900
+
 # From version 2.0.7 cuckoo API has authentication support.
 # New installations create a bearer token by default and require it but upgraded
 # installations don't automatically get one.

--- a/systemd/cuckoo-api.service
+++ b/systemd/cuckoo-api.service
@@ -7,7 +7,6 @@ Requires=mysql.service
 ExecStart=/opt/cuckoo/bin/cuckoo api
 Restart=on-failure
 User=cuckoo
-Group=cuckoo
 WorkingDirectory=/var/lib/cuckoo
 
 [Install]

--- a/systemd/cuckoo-process@.service
+++ b/systemd/cuckoo-process@.service
@@ -7,7 +7,6 @@ Requires=mysql.service
 ExecStart=/opt/cuckoo/bin/cuckoo process instance%i
 Restart=on-failure
 User=cuckoo
-Group=cuckoo
 WorkingDirectory=/var/lib/cuckoo
 
 [Install]

--- a/systemd/cuckoo-web.service
+++ b/systemd/cuckoo-web.service
@@ -7,7 +7,6 @@ Requires=mysql.service
 ExecStart=/opt/cuckoo/bin/cuckoo web
 Restart=on-failure
 User=cuckoo
-Group=cuckoo
 WorkingDirectory=/var/lib/cuckoo
 
 [Install]

--- a/systemd/cuckoo.service
+++ b/systemd/cuckoo.service
@@ -7,7 +7,6 @@ Requires=mysql.service
 ExecStart=/opt/cuckoo/bin/cuckoo
 Restart=on-failure
 User=cuckoo
-Group=cuckoo
 WorkingDirectory=/var/lib/cuckoo
 LimitNOFILE=32768
 


### PR DESCRIPTION
Make peekaboo.conf owned by user root and group peekaboo and
group-readable. This way, user peekaboo retains read access but cannot
change the configuration file.

Closes #27.