### PR TITLE
Separate cuckoo

### DIFF
--- a/PeekabooAV-install.sh
+++ b/PeekabooAV-install.sh
@@ -119,7 +119,7 @@ bail_unknown_argument() {
 }
 
 quiet=
-pyver=2
+pyver=3
 while [ -n "$1" ] ; do
 	case "$1" in
 		--python=*)

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -228,6 +228,7 @@
           - libjpeg-dev
           - zlib1g-dev
           - swig
+          - build-essential
           # required to install mysql python module in venv using pip
           - libmysqlclient-dev
     - name: Install Cuckoo packages
@@ -395,6 +396,7 @@
     - name: Install Peekaboo system dependencies
       apt:
         name:
+          - build-essential
           # required to install mysql python module in venv using pip
           - libmysqlclient-dev
     - name: Install Peekaboo python 2 system dependencies

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -720,4 +720,5 @@
         path: "{{ item }}"
       with_items:
         - cuckoo_db_password
+        - cuckoo_api_token
         - peekaboo_db_password

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -111,33 +111,6 @@
           - git
           - curl
           - socat
-    - name: Install Cuckoo and Peekaboo system dependencies
-      apt:
-        name:
-          - python
-          - python-pip
-          - python-dev
-          - libffi-dev
-          - libssl-dev
-          - python-virtualenv
-          - python-setuptools
-          - libjpeg-dev
-          - zlib1g-dev
-          - swig
-          - sqlite3
-          - swig
-          - mongodb
-          # required to install mysql python module in venv using pip
-          - libmysqlclient-dev
-    - name: Install Peekaboo python 3 system dependencies
-      apt:
-        name:
-          - python3
-          - python3-pip
-          - python3-dev
-          - python3-virtualenv
-          - python3-setuptools
-      when: pyver == 3
 
 - name: Install tcpdump and set capability
   hosts: peekabooav_server
@@ -238,6 +211,23 @@
       - cuckoo-api.service
       - cuckoo-sandbox.service
   tasks:
+    - name: Install Cuckoo system dependencies
+      apt:
+        name:
+          - python
+          - python-pip
+          - python-dev
+          - python-virtualenv
+          - python-setuptools
+          - mongodb
+          - libffi-dev
+          - libssl-dev
+          - libjpeg-dev
+          - zlib1g-dev
+          - sqlite3
+          - swig
+          # required to install mysql python module in venv using pip
+          - libmysqlclient-dev
     - name: Install Cuckoo packages
       pip:
         name:
@@ -400,6 +390,29 @@
   vars:
     python_exe: "python{{ pyver }}"
   tasks:
+    - name: Install Peekaboo system dependencies
+      apt:
+        name:
+          # required to install mysql python module in venv using pip
+          - libmysqlclient-dev
+    - name: Install Peekaboo python 2 system dependencies
+      apt:
+        name:
+          - python
+          - python-pip
+          - python-dev
+          - python-virtualenv
+          - python-setuptools
+      when: pyver == 2
+    - name: Install Peekaboo python 3 system dependencies
+      apt:
+        name:
+          - python3
+          - python3-pip
+          - python3-dev
+          - python3-virtualenv
+          - python3-setuptools
+      when: pyver == 3
     - name: Check if Peekaboo is switching python versions
       stat: path=/opt/peekaboo/bin/python
       register: peekaboo_python

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -126,6 +126,11 @@
           # to be able to connect to the database in the next step
           - python-mysqldb
 
+    - name: Start database service
+      systemd:
+        name: mysql
+        state: started
+
     - name: Create databases
       mysql_db:
         name: "{{ item }}"

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -355,6 +355,14 @@
       args:
         chdir: /var/lib/cuckoo
 
+    # cuckoo ignores the api token in custom.kv.conf :(
+    - name: Hack api token into config
+      tags: cuckooconf
+      replace:
+        path: /var/lib/cuckoo/.cuckoo/conf/cuckoo.conf
+        regexp: '^api_token = .*'
+        replace: "api_token = {{ cuckoo_api_token }}"
+
     - name: Install cuckoo community signatures
       command: /opt/cuckoo/bin/cuckoo community
       become_user: cuckoo

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -215,16 +215,13 @@
       apt:
         name:
           - python
-          - python-pip
           - python-dev
           - python-virtualenv
-          - python-setuptools
           - mongodb
           - libffi-dev
           - libssl-dev
           - libjpeg-dev
           - zlib1g-dev
-          - sqlite3
           - swig
           # required to install mysql python module in venv using pip
           - libmysqlclient-dev
@@ -234,7 +231,7 @@
           - pip
           - setuptools
           - cuckoo
-          - mysql
+          - mysqlclient
         virtualenv: /opt/cuckoo
         virtualenv_python: python2.7
 
@@ -399,19 +396,15 @@
       apt:
         name:
           - python
-          - python-pip
           - python-dev
           - python-virtualenv
-          - python-setuptools
       when: pyver == 2
     - name: Install Peekaboo python 3 system dependencies
       apt:
         name:
           - python3
-          - python3-pip
           - python3-dev
           - python3-virtualenv
-          - python3-setuptools
       when: pyver == 3
     - name: Check if Peekaboo is switching python versions
       stat: path=/opt/peekaboo/bin/python
@@ -434,7 +427,7 @@
     - name: Install Peekaboo optional components
       pip:
         name:
-          - mysql
+          - mysqlclient
         virtualenv: /opt/peekaboo
         virtualenv_python: "{{ python_exe }}"
 

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -112,21 +112,6 @@
           - curl
           - socat
 
-- name: Install tcpdump and set capability
-  hosts: peekabooav_server
-  gather_facts: no
-  become: true
-  tasks:
-    - name: Install tcpdump
-      apt:
-        name: tcpdump
-        state: latest
-    - name: Set capability
-      capabilities:
-        path: /usr/sbin/tcpdump
-        capability: cap_net_raw,cap_net_admin=eip
-        state: present
-
 - name: Install mysql database and setup users and databases
   hosts: peekabooav_server
   gather_facts: no
@@ -183,6 +168,26 @@
         uid: 151
         home: /var/lib/cuckoo
 
+- name: Install tcpdump and set capability
+  hosts: cuckoo_server
+  gather_facts: no
+  become: true
+  tasks:
+    - name: Install tcpdump
+      apt:
+        name: tcpdump
+        state: latest
+    - name: Restrict access to tcpdump
+      file:
+        path: /usr/sbin/tcpdump
+        mode: 0710
+        owner: root
+        group: cuckoo
+    - name: Set capability
+      capabilities:
+        path: /usr/sbin/tcpdump
+        capability: cap_net_raw,cap_net_admin=eip
+        state: present
 
 - name: Install Cuckoo
   hosts: cuckoo_server

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -193,22 +193,22 @@
         priv: 'peekaboo.*:ALL,GRANT'
         state: present
 
-- name: Create a new peekaboo user and group 
-  hosts: peekabooav_server
+- name: Create a new cuckoo user and group
+  hosts: cuckoo_server
   gather_facts: no
   become: true
   tasks:
-    - name: Create a new group peekaboo
+    - name: Create a new group cuckoo
       group:
-        name: peekaboo
+        name: cuckoo
         state: present
-        gid: 150
-    - name: Create a new user peekaboo
+        gid: 151
+    - name: Create a new user cuckoo
       user:
-        name: peekaboo
-        group: peekaboo
-        uid: 150
-        home: /var/lib/peekaboo
+        name: cuckoo
+        group: cuckoo
+        uid: 151
+        home: /var/lib/cuckoo
 
 
 - name: Install Cuckoo
@@ -285,17 +285,17 @@
 
     - name: Secure storage directory
       file:
-        path: /var/lib/peekaboo
+        path: /var/lib/cuckoo
         mode: 0700
 
-    - name: Copy /var/lib/peekaboo/vboxmanage.conf
+    - name: Copy /var/lib/cuckoo/vboxmanage.conf
       # The configuration contains IP address and username of the
       # target user on the host that owns all virtual box vms.
       copy:
         src: vbox/vboxmanage.conf
-        dest: /var/lib/peekaboo/vboxmanage.conf
-        owner: peekaboo
-        group: peekaboo
+        dest: /var/lib/cuckoo/vboxmanage.conf
+        owner: cuckoo
+        group: cuckoo
         mode: 0644
         backup: true
 
@@ -304,20 +304,20 @@
         name: ssh
         state: latest
 
-    - name: Setup ssh key for peekaboo user
+    - name: Setup ssh key for cuckoo user
       file:
-        path: /var/lib/peekaboo/.ssh
+        path: /var/lib/cuckoo/.ssh
         state: directory
         mode: 0700
-        owner: peekaboo
-        group: peekaboo
+        owner: cuckoo
+        group: cuckoo
 
     - name: This key will have to be allowed on the host to authenticate the vm user
-      become_user: peekaboo
-      command: ssh-keygen -t ed25519 -f /var/lib/peekaboo/.ssh/id_ed25519 -P ''
+      become_user: cuckoo
+      command: ssh-keygen -t ed25519 -f /var/lib/cuckoo/.ssh/id_ed25519 -P ''
       args:
-        chdir: /var/lib/peekaboo
-        creates: /var/lib/peekaboo/.ssh/id_ed25519
+        chdir: /var/lib/cuckoo
+        creates: /var/lib/cuckoo/.ssh/id_ed25519
 
     - name: Create Cuckoo configuration directory /opt/cuckoo/etc
       tags: cuckooconf
@@ -330,8 +330,8 @@
       template:
         src: cuckoo/custom.kv.conf
         dest: /opt/cuckoo/etc/custom.kv.conf
-        owner: peekaboo
-        group: peekaboo
+        owner: cuckoo
+        group: cuckoo
         mode: 0600
         backup: true
 
@@ -342,29 +342,29 @@
     # There does not seem a way to first update the config and then the
     # database. Throwing away the whole old cwd seems too drastic a solution.
     - name: Check if cuckoo config exists
-      stat: path=/var/lib/peekaboo/.cuckoo/conf/cuckoo.conf
+      stat: path=/var/lib/cuckoo/.cuckoo/conf/cuckoo.conf
       register: cuckoo_conf
 
     - name: Potentially hack new DB password into old config
       tags: cuckooconf
       replace:
-        path: /var/lib/peekaboo/.cuckoo/conf/cuckoo.conf
+        path: /var/lib/cuckoo/.cuckoo/conf/cuckoo.conf
         regexp: '^connection = .*'
         replace: "connection = mysql://cuckoo:{{ cuckoo_db_password }}@{{ mariadb_server }}/cuckoo"
       when: cuckoo_conf.stat.exists == True
 
-    - name: Initial run of Cuckoo to create default configuration in peekaboo $HOME
+    - name: Initial run of Cuckoo to create default configuration in cuckoo $HOME
       tags: cuckooconf
-      become_user: peekaboo
+      become_user: cuckoo
       command: /opt/cuckoo/bin/cuckoo init --conf=/opt/cuckoo/etc/custom.kv.conf
       args:
-        chdir: /var/lib/peekaboo
+        chdir: /var/lib/cuckoo
 
     - name: Install cuckoo community signatures
       command: /opt/cuckoo/bin/cuckoo community
-      become_user: peekaboo
+      become_user: cuckoo
       args:
-        chdir: /var/lib/peekaboo
+        chdir: /var/lib/cuckoo
 
     - name: Start and enable Cuckoo services
       systemd:
@@ -373,6 +373,24 @@
         state: started
         daemon_reload: yes
       with_items: "{{ services + processor_services }}"
+
+
+- name: Create a new peekaboo user and group
+  hosts: peekabooav_server
+  gather_facts: no
+  become: true
+  tasks:
+    - name: Create a new group peekaboo
+      group:
+        name: peekaboo
+        state: present
+        gid: 150
+    - name: Create a new user peekaboo
+      user:
+        name: peekaboo
+        group: peekaboo
+        uid: 150
+        home: /var/lib/peekaboo
 
 
 - name: Install Peekaboo

--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -180,7 +180,9 @@
     - name: Restrict access to tcpdump
       file:
         path: /usr/sbin/tcpdump
-        mode: 0710
+        # cuckoo stats the sniffer during configuration initialisation so we
+        # need r+x for group cuckoo here
+        mode: 0750
         owner: root
         group: cuckoo
     - name: Set capability

--- a/cuckoo/custom.kv.conf
+++ b/cuckoo/custom.kv.conf
@@ -4,6 +4,7 @@ cuckoo.cuckoo.freespace = 256
 cuckoo.resultserver.ip = 192.168.56.5
 cuckoo.processing.resolve_dns = no
 cuckoo.database.connection = mysql://cuckoo:{{ cuckoo_db_password }}@{{ mariadb_server }}/cuckoo
+cuckoo.cuckoo.api_token = {{ cuckoo_api_token }}
 
 reporting.mongodb.enabled = yes
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,4 +10,4 @@ peekaboo_db_password: "{{ lookup('password', 'peekaboo_db_password length=15 cha
 cuckoo_processors: 5
 
 # default for the python interpreter version to use
-pyver: 2
+pyver: 3

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -5,6 +5,7 @@ cuckooapi_server: localhost
 mariadb_server: localhost
 
 cuckoo_db_password: "{{ lookup('password', 'cuckoo_db_password length=15 chars=ascii_letters') }}"
+cuckoo_api_token: "{{ lookup('password', 'cuckoo_api_token length=22 chars=ascii_letters') }}"
 peekaboo_db_password: "{{ lookup('password', 'peekaboo_db_password length=15 chars=ascii_letters') }}"
 
 cuckoo_processors: 5

--- a/peekaboo/peekaboo.conf
+++ b/peekaboo/peekaboo.conf
@@ -86,6 +86,7 @@ url             :    mysql+mysqldb://peekaboo:{{ peekaboo_db_password }}@{{ mari
 # New installations create a bearer token by default and require it but upgraded
 # installations don't automatically get one.
 #api_token        :    <empty>
+api_token        :    {{ cuckoo_api_token }}
 
 [cluster]
 # if multiple instances are to run in parallel and avoid concurrent analysis of

--- a/peekaboo/peekaboo.conf
+++ b/peekaboo/peekaboo.conf
@@ -9,15 +9,12 @@
 group            :    amavis
 #socket_file      :    /var/run/peekaboo/peekaboo.sock
 #pid_file         :    /var/run/peekaboo/peekaboo.pid
-#interpreter      :    /usr/bin/python -u
+#interpreter      :    /usr/bin/python2 -u
 # alternatvely, if using cuckooprocessor.sh as exec below:
 #interpreter      :    /bin/bash
 #worker_count     :    3
 #sample_base_dir  :    /tmp
 #job_hash_regex   :    /amavis/tmp/([^/]+)/parts/
-# 'yes' or 'no'  to use Peekaboo's debug module, which allows
-# additional code execution at runtime.
-#use_debug_module :    no
 # Whether or not to cleanup temporary files under /tmp
 #keep_mail_data   :    no
 #processing_info_dir : /var/lib/peekaboo/malware_reports
@@ -60,6 +57,11 @@ url             :    mysql+mysqldb://peekaboo:{{ peekaboo_db_password }}@{{ mari
 # PostgreSQL
 # url             :    postgresql://user:password@host:port/database
 
+# Enable additional logging by the SQLAlchemy database module beyond Peekaboo's
+# own logging. Can be considered another set of debug logging even beyond
+# Peekaboo's DEBUG log level.
+#log_level        :    WARNING
+
 #
 # Cuckoo specific settings
 #
@@ -80,6 +82,10 @@ url             :    mysql+mysqldb://peekaboo:{{ peekaboo_db_password }}@{{ mari
 # api mode
 #url              :    http://127.0.0.1:8090
 #poll_interval    :    5
+# From version 2.0.7 cuckoo API has authentication support.
+# New installations create a bearer token by default and require it but upgraded
+# installations don't automatically get one.
+#api_token        :    <empty>
 
 [cluster]
 # if multiple instances are to run in parallel and avoid concurrent analysis of
@@ -93,7 +99,7 @@ url             :    mysql+mysqldb://peekaboo:{{ peekaboo_db_password }}@{{ mari
 # number of seconds after which in-flight markers of samples are to be
 # removed/ignored, assuming that the instance processing them has crashed or
 # been shut down.
-#stale_in_flight_threshold: 3600
+#stale_in_flight_threshold: 900
 
 # Interval in which to check if other instances of a Peekaboo cluster have
 # finished processing samples we have held.

--- a/systemd/cuckoo-api.service
+++ b/systemd/cuckoo-api.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cuckoo REST API
-After=network.target
+After=network.target mysql.service
 
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo api

--- a/systemd/cuckoo-api.service
+++ b/systemd/cuckoo-api.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Cuckoo REST API
 After=network.target mysql.service
+Requires=mysql.service
 
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo api

--- a/systemd/cuckoo-api.service
+++ b/systemd/cuckoo-api.service
@@ -5,9 +5,9 @@ After=network.target
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo api
 Restart=on-failure
-User=peekaboo
-Group=peekaboo
-WorkingDirectory=/var/lib/peekaboo
+User=cuckoo
+Group=cuckoo
+WorkingDirectory=/var/lib/cuckoo
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/cuckoo-process@.service
+++ b/systemd/cuckoo-process@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cuckoo Sandbox Processing Service %i
-After=network.target cuckoo.service
+After=network.target cuckoo.service mysql.service
 
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo process instance%i

--- a/systemd/cuckoo-process@.service
+++ b/systemd/cuckoo-process@.service
@@ -5,9 +5,9 @@ After=network.target cuckoo.service
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo process instance%i
 Restart=on-failure
-User=peekaboo
-Group=peekaboo
-WorkingDirectory=/var/lib/peekaboo
+User=cuckoo
+Group=cuckoo
+WorkingDirectory=/var/lib/cuckoo
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/cuckoo-process@.service
+++ b/systemd/cuckoo-process@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Cuckoo Sandbox Processing Service %i
 After=network.target cuckoo.service mysql.service
+Requires=mysql.service
 
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo process instance%i

--- a/systemd/cuckoo-rooter.service
+++ b/systemd/cuckoo-rooter.service
@@ -3,9 +3,9 @@ Description=Cuckoo Rooter Service
 After=network.target
 
 [Service]
-ExecStart=/opt/cuckoo/bin/cuckoo rooter -g peekaboo
+ExecStart=/opt/cuckoo/bin/cuckoo rooter -g cuckoo
 Restart=on-failure
-WorkingDirectory=/var/lib/peekaboo
+WorkingDirectory=/var/lib/cuckoo
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/cuckoo-web.service
+++ b/systemd/cuckoo-web.service
@@ -5,9 +5,9 @@ After=network.target
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo web
 Restart=on-failure
-User=peekaboo
-Group=peekaboo
-WorkingDirectory=/var/lib/peekaboo
+User=cuckoo
+Group=cuckoo
+WorkingDirectory=/var/lib/cuckoo
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/cuckoo-web.service
+++ b/systemd/cuckoo-web.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Cuckoo Web Service
 After=network.target mysql.service
+Requires=mysql.service
 
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo web

--- a/systemd/cuckoo-web.service
+++ b/systemd/cuckoo-web.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cuckoo Web Service
-After=network.target
+After=network.target mysql.service
 
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo web

--- a/systemd/cuckoo.service
+++ b/systemd/cuckoo.service
@@ -8,6 +8,7 @@ Restart=on-failure
 User=cuckoo
 Group=cuckoo
 WorkingDirectory=/var/lib/cuckoo
+LimitNOFILE=32768
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/cuckoo.service
+++ b/systemd/cuckoo.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cuckoo Sandbox Service
-After=network.target cuckoo-rooter.service
+After=network.target cuckoo-rooter.service mysql.service
 
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo

--- a/systemd/cuckoo.service
+++ b/systemd/cuckoo.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Cuckoo Sandbox Service
 After=network.target cuckoo-rooter.service mysql.service
+Requires=mysql.service
 
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo

--- a/systemd/cuckoo.service
+++ b/systemd/cuckoo.service
@@ -5,9 +5,9 @@ After=network.target cuckoo-rooter.service
 [Service]
 ExecStart=/opt/cuckoo/bin/cuckoo
 Restart=on-failure
-User=peekaboo
-Group=peekaboo
-WorkingDirectory=/var/lib/peekaboo
+User=cuckoo
+Group=cuckoo
+WorkingDirectory=/var/lib/cuckoo
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
A number of fixes broadly centered around separating cuckoo from peekaboo now that we're no longer using embed mode by default. Fix up systemd unit ordering and dependency package installation. Switch to python 3 for peekaboo by default. Also try to tackle automatic cuckoo api token generation and securing tcpdump access.