### PR TITLE
cuckoo: Work around database encoding problems

### DIFF
--- a/cuckoo/custom.kv.conf
+++ b/cuckoo/custom.kv.conf
@@ -3,7 +3,8 @@ cuckoo.cuckoo.process_results = no
 cuckoo.cuckoo.freespace = 256
 cuckoo.resultserver.ip = 192.168.56.5
 cuckoo.processing.resolve_dns = no
-cuckoo.database.connection = mysql://cuckoo:{{ cuckoo_db_password }}@{{ mariadb_server }}/cuckoo
+# charset=utf8 works around latin1 encoding default in mysqlclient with python2
+cuckoo.database.connection = mysql://cuckoo:{{ cuckoo_db_password }}@{{ mariadb_server }}/cuckoo?charset=utf8
 cuckoo.cuckoo.api_token = {{ cuckoo_api_token }}
 
 reporting.mongodb.enabled = yes


### PR DESCRIPTION
Problems like scVENUS/PeekabooAV#136 seem to be caused by a (still
somewhat mysterious) latin1 encoding default in the mysqlclient package
or rather libmysqlclient C library it uses. This seems to be mitigated
in python3. As a workaround for python2 we add ?charset=utf8 to the
connect string.

Closes scVENUS/PeekabooAV#136.