### PR TITLE
peekaboo: Adjust for recent development changes

### DIFF
--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -555,6 +555,16 @@
         mode: 0640
         backup: true
 
+    - name: Place analyzers config in /opt/peekaboo/etc
+      tags: peekabooconf
+      template:
+        src: peekaboo/analyzers.conf
+        dest: /opt/peekaboo/etc/analyzers.conf
+        owner: root
+        group: peekaboo
+        mode: 0640
+        backup: true
+
     - name: Check if an old Peekaboo ruleset.conf exists in /opt/peekaboo
       stat: path=/opt/peekaboo/ruleset.conf
       register: ruleset_conf_old_stat

--- a/peekaboo/analyzers.conf
+++ b/peekaboo/analyzers.conf
@@ -1,0 +1,27 @@
+# Cuckoo analyzer settings
+[cuckoo]
+# where to reach the Cuckoo REST API
+#url: http://127.0.0.1:8090
+
+# how long to wait inbetween checks of job status
+#poll_interval: 5
+
+# Submit samples with their original filenames if available. Enhances
+# authenticity of analysis environment but also leaks original filenames into
+# Cuckoo's database.
+#submit_original_filename : yes
+
+# Specify how long to track running Cuckoo jobs before giving up on them. This
+# does not actively cancel jobs. It's rather meant to handle cases where jobs
+# have for some reason been dropped by or got stuck within Cuckoo. This value
+# is unrelated to how long our client is willing to wait for a result because
+# even if it gives up on us we would normally want to learn and cache the job
+# result because the analysis was expensive and the sample might be presented
+# to us again.
+#maximum_job_age : 900
+
+# From version 2.0.7 cuckoo API has authentication support.
+# New installations create a bearer token by default and require it but upgraded
+# installations don't automatically get one.
+#api_token        :    <empty>
+api_token        :    {{ cuckoo_api_token }}

--- a/peekaboo/peekaboo.conf
+++ b/peekaboo/peekaboo.conf
@@ -1,6 +1,6 @@
 #
 # Peekaboo configuration file
-# Copyright (C) 2016-2019 science + computing ag
+# Copyright (C) 2016-2020 science + computing ag
 #
 
 
@@ -35,6 +35,8 @@ socket_group     :    amavis
 [ruleset]
 #config           :    /opt/peekaboo/etc/ruleset.conf
 
+[analyzers]
+#config: /opt/peekaboo/etc/analyzers.conf
 
 #
 # Logging configuration
@@ -65,47 +67,6 @@ url             :    mysql+mysqldb://peekaboo:{{ peekaboo_db_password }}@{{ mari
 # own logging. Can be considered another set of debug logging even beyond
 # Peekaboo's DEBUG log level.
 #log_level        :    WARNING
-
-#
-# Cuckoo specific settings
-#
-[cuckoo]
-# mode has two options:
-#  embed   : for legacy embeded mode
-#  api     : to access cuckoo via the REST api
-#mode             :    api
-
-# embed mode
-#exec             :    /opt/cuckoo/bin/cuckoo
-# alternatively: Run multiple external process instances, needs interpreter set
-# to bash above.
-#exec             :    /opt/peekaboo/bin/cuckooprocessor.sh
-#submit           :    /opt/cuckoo/bin/cuckoo submit
-#storage_path     :    /var/lib/peekaboo/.cuckoo/storage
-
-# api mode
-#url              :    http://127.0.0.1:8090
-#poll_interval    :    5
-
-# Submit samples with their original filenames if available. Enhances
-# authenticity of analysis environment but also leaks original filenames into
-# Cuckoo's database.
-#submit_original_filename : yes
-
-# Specify how long to track running Cuckoo jobs before giving up on them. This
-# does not actively cancel jobs. It's rather meant to handle cases where jobs
-# have for some reason been dropped by or got stuck within Cuckoo. This value
-# is unrelated to how long our client is willing to wait for a result because
-# even if it gives up on us we would normally want to learn and cache the job
-# result because the analysis was expensive and the sample might be presented
-# to us again.
-#maximum_job_age : 900
-
-# From version 2.0.7 cuckoo API has authentication support.
-# New installations create a bearer token by default and require it but upgraded
-# installations don't automatically get one.
-#api_token        :    <empty>
-api_token        :    {{ cuckoo_api_token }}
 
 [cluster]
 # if multiple instances are to run in parallel and avoid concurrent analysis of


### PR DESCRIPTION
Adjust the installer for recent changes in Peekaboo, particularly the
introduction of analyzers.conf. Synchronise the configuration files and
add the necessary Ansible logic.