### PR TITLE
Docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:18.04
-
-ARG MODE=api
+FROM ubuntu:18.04 AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /peekaboo
 
+# this approach is fat because we install postfix and amavis as well. We need a
+# network API towards amavis to be able to put it in a separate container.
 RUN apt-get -y update && \
 	apt-get -y dist-upgrade && \
 	apt-get install -y \
@@ -13,17 +13,46 @@ RUN apt-get -y update && \
 		postfix \
 		amavisd-new \
 		build-essential \
-		python-dev \
+		python3-dev \
 		libjpeg-dev \
-		zlib1g-dev
+		zlib1g-dev \
+		libmysqlclient-dev && \
+	apt-get clean all
 
-RUN [ "${MODE}" != "embed" ] || \
-	( virtualenv /opt/cuckoo && \
-		/opt/cuckoo/bin/pip install cuckoo )
-
-COPY PeekabooAV .
-RUN virtualenv /opt/peekaboo && \
-	/opt/peekaboo/bin/pip install PeekabooAV
+COPY PeekabooAV /peekaboo/PeekabooAV/
+RUN virtualenv --python=/usr/bin/python3 /opt/peekaboo && \
+	cd PeekabooAV && \
+	/opt/peekaboo/bin/pip3 install . && \
+	/opt/peekaboo/bin/pip3 install mysqlclient
+RUN rm -rf /peekaboo
 
 RUN groupadd -g 150 peekaboo
 RUN useradd -g 150 -u 150 -m -d /var/lib/peekaboo peekaboo
+
+RUN mkdir /opt/peekaboo/etc
+COPY peekaboo/peekaboo.conf /opt/peekaboo/etc/peekaboo.conf.template
+RUN touch /opt/peekaboo/etc/peekaboo.conf && \
+	chmod 600 /opt/peekaboo/etc/peekaboo.conf && \
+	chown peekaboo:root /opt/peekaboo/etc/peekaboo.conf
+
+COPY peekaboo/analyzers.conf /opt/peekaboo/etc/analyzers.conf.template
+RUN touch /opt/peekaboo/etc/analyzers.conf && \
+	chmod 600 /opt/peekaboo/etc/analyzers.conf && \
+	chown peekaboo:root /opt/peekaboo/etc/analyzers.conf
+
+RUN cp /opt/peekaboo/share/doc/peekaboo/ruleset.conf.sample /opt/peekaboo/etc/ruleset.conf
+
+RUN mkdir /run/peekaboo && \
+	chown peekaboo: /run/peekaboo
+
+FROM scratch
+COPY --from=build / /
+
+USER peekaboo
+CMD sed -e "s,{{ peekaboo_db_password }},${PEEKABOO_DB_PASSWORD:-secret},g" \
+			-e "s,{{ mariadb_server }},${PEEKABOO_DB_SERVER:-mariadb},g" \
+		/opt/peekaboo/etc/peekaboo.conf.template > /opt/peekaboo/etc/peekaboo.conf && \
+	sed -e "s,{{ cortex_url }},${PEEKABOO_CORTEX_URL:-http://cortex:9001},g" \
+			-e "s,{{ cortex_api_token }},${PEEKABOO_CORTEX_API_TOKEN:-secret},g" \
+		/opt/peekaboo/etc/analyzers.conf.template > /opt/peekaboo/etc/analyzers.conf && \
+	/opt/peekaboo/bin/peekaboo -c /opt/peekaboo/etc/peekaboo.conf -D

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "2"
+
+# run using e.g.:
+# job_directory=$PWD/jobs elastic_data=$PWD/elastic mysql_data=$PWD/mysql docker-compose up
+services:
+  elasticsearch:
+    image: elasticsearch:7.8.1
+    environment:
+      - http.host=0.0.0.0
+      - discovery.type=single-node
+      - script.allowed_types=inline
+      - thread_pool.search.queue_size=100000
+      - thread_pool.write.queue_size=10000
+    volumes:
+      - ${elastic_data}:/usr/share/elasticsearch/data
+  cortex:
+    image: thehiveproject/cortex:3.1.0-0.2RC1
+    environment:
+      - job_directory=${job_directory}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${job_directory}:${job_directory}
+    depends_on:
+      - elasticsearch
+    ports:
+      - "0.0.0.0:9001:9001"
+  mariadb:
+    image: mariadb/server
+    environment:
+      - MARIADB_RANDOM_ROOT_PASSWORD=true
+      - MARIADB_DATABASE=peekaboo
+      - MARIADB_USER=peekaboo
+      - MARIADB_PASSWORD=peekaboo
+    volumes:
+      - ${mysql_data}:/var/lib/mysql
+  peekabooav:
+    image: peekabooav
+    environment:
+      - PEEKABOO_DB_PASSWORD=peekaboo
+      - PEEKABOO_CORTEX_API_TOKEN=Kv8a+20IwlFnxrDVTVjS9tshlUe2498a
+#    volumes:
+#      - ./ruleset.conf:/opt/peekaboo/etc/ruleset.conf
+    depends_on:
+      - mariadb
+      - cortex
+#    ports:
+#      - "0.0.0.0:10024:10024"

--- a/peekaboo/analyzers.conf
+++ b/peekaboo/analyzers.conf
@@ -25,3 +25,30 @@
 # installations don't automatically get one.
 #api_token        :    <empty>
 api_token        :    {{ cuckoo_api_token }}
+
+# Cortex analyzer settings
+[cortex]
+# where to reach the Cortex REST API
+#url: http://127.0.0.1:9001
+url: {{ cortex_url }}
+
+# Token to authenticate to the Cortex REST API with.
+#api_token        :    <empty>
+api_token        :    {{ cortex_api_token }}
+
+# how long to wait inbetween checks of job status
+#poll_interval: 5
+
+# Submit samples with their original filenames if available. Enhances
+# authenticity of analysis environment but also leaks original filenames into
+# Cortex's database.
+#submit_original_filename : yes
+
+# Specify how long to track running Cortex jobs before giving up on them. This
+# does not actively cancel jobs. It's rather meant to handle cases where jobs
+# have for some reason been dropped by or got stuck within Cortex. This value
+# is unrelated to how long our client is willing to wait for a result because
+# even if it gives up on us we would normally want to learn and cache the job
+# result because the analysis was expensive and the sample might be presented
+# to us again.
+#maximum_job_age : 900


### PR DESCRIPTION
Add a docker-compose configuration that orchestrates a mariadb
container for our database as well as a cortex and its requirement
of an elasticsearch instance. To be extended.

Make our Dockerfile produce an actually useable container. Still needs
an accessible frontend (amavis/postfix) but can already accept analysis
requests via volume mount and exec of peekaboo-util scan-file.

Remove embed mode support.

Add a section for Cortex configuration to analyzers.conf to keep it
in sync with main Peekaboo development.