### PR TITLE
Installer updates

### DIFF
--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -763,4 +763,5 @@
       with_items:
         - cuckoo_db_password
         - cuckoo_api_token
+        - cortex_api_token
         - peekaboo_db_password

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,10 +2,14 @@
 peekabooav_server: localhost
 peekabooav_server_fqdn: "{{ ansible_fqdn }}"
 cuckooapi_server: localhost
+cortex_server: localhost
 mariadb_server: localhost
 
 cuckoo_db_password: "{{ lookup('password', 'cuckoo_db_password length=15 chars=ascii_letters') }}"
 cuckoo_api_token: "{{ lookup('password', 'cuckoo_api_token length=22 chars=ascii_letters') }}"
+cortex_api_token: "{{ lookup('password', 'cortex_api_token length=22 chars=ascii_letters') }}"
 peekaboo_db_password: "{{ lookup('password', 'peekaboo_db_password length=15 chars=ascii_letters') }}"
 
 cuckoo_processors: 5
+
+cortex_url: "http://{{ cortex_server }}:9001"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -12,4 +12,5 @@ peekaboo_db_password: "{{ lookup('password', 'peekaboo_db_password length=15 cha
 
 cuckoo_processors: 5
 
+cuckooapi_url: "http://{{ cuckooapi_server }}:8090"
 cortex_url: "http://{{ cortex_server }}:9001"

--- a/peekaboo/analyzers.conf
+++ b/peekaboo/analyzers.conf
@@ -2,6 +2,7 @@
 [cuckoo]
 # where to reach the Cuckoo REST API
 #url: http://127.0.0.1:8090
+url: {{ cuckooapi_url }}
 
 # how long to wait inbetween checks of job status
 #poll_interval: 5

--- a/peekaboo/peekaboo.conf
+++ b/peekaboo/peekaboo.conf
@@ -10,7 +10,10 @@
 #group            :    <empty>
 #host             :    127.0.0.1
 #port             :    8100
-#pid_file         :    /var/run/peekaboo/peekaboo.pid
+
+# can be set to e.g. /run/peekaboo/peekaboo.pid to create a PID file in forking
+# daemon mode
+#pid_file         :    <empty>
 #worker_count     :    3
 #processing_info_dir : /var/lib/peekaboo/malware_reports
 


### PR DESCRIPTION
These are some minor updates to the installer to make it work again. We broke it with our container and Cortex additions by introducing two undefined placeholders to Ansible templates. Also, we sync up the peekaboo.conf (in addition to what's done in #71) to account for scVENUS/PeekabooAV#200.

Tested with vagrant on Ubuntu 18.04 and 20.04 as well as my Ubuntu 20.04 devel box (which has a lot more history and still works).