### PR TITLE
2.1 release prep

### DIFF
--- a/PeekabooAV-install.yml
+++ b/PeekabooAV-install.yml
@@ -500,9 +500,11 @@
         virtualenv: /opt/peekaboo
       when: manually_supplied_peekaboo.stat.exists
 
-    - name: Install latest Peekaboo release from PyPI
+    - name: Install Peekaboo release from PyPI
       pip:
-        name: peekabooav
+        # version is constrained to latest point release of current minor
+        # release by default
+        name: peekabooav{{ peekaboo_pip_constraint }}
         state: latest
         virtualenv: /opt/peekaboo
       when: not manually_supplied_peekaboo.stat.exists

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ cd PeekabooAV-Installer/
 ./PeekabooAV-install.sh
 ```
 
+**NOTE**: Point releases of the Installer and PeekabooAV are independent.
+A particular version of the Installer always installs the latest
+point release of PeekabooAV of the corresponding minor release branch.
+So Installer 2.1.2 might very well install PeekabooAV 2.1.8 if it's available.
+This behaviour can be changed by adjusting `peekaboo_pip_constraint` in
+[`group_vars/all.yml`](group_vars/all.yml#15).
+
 Or for testing most recent changes of the repository
 ```
 git clone https://github.com/scVENUS/PeekabooAV-Installer

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ process of a testing environment is also available.
 ### This is what you type (copy - paste)
 For a released version, e.g. 2.0
 ```
-git clone -b v2.0 --recurse-submodules https://github.com/scvenus/peekabooav-installer
+git clone -b v2.0 https://github.com/scvenus/peekabooav-installer
 cd peekabooav-installer/
 ./PeekabooAV-install.sh
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd PeekabooAV-Installer/
 ./PeekabooAV-install.sh
 ```
 
-Or for testing most resent changes of the repository
+Or for testing most recent changes of the repository
 ```
 git clone https://github.com/scVENUS/PeekabooAV-Installer
 cd PeekabooAV-Installer/

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ process of a testing environment is also available.
 
 
 ### This is what you type (copy - paste)
-For a released version, e.g. 2.0
+For a released version, e.g. 2.1
 ```
-git clone -b v2.0 https://github.com/scVENUS/PeekabooAV-Installer
+git clone -b v2.1 https://github.com/scVENUS/PeekabooAV-Installer
 cd PeekabooAV-Installer/
 ./PeekabooAV-install.sh
 ```

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ process of a testing environment is also available.
 ### This is what you type (copy - paste)
 For a released version, e.g. 2.0
 ```
-git clone -b v2.0 https://github.com/scvenus/peekabooav-installer
-cd peekabooav-installer/
+git clone -b v2.0 https://github.com/scVENUS/PeekabooAV-Installer
+cd PeekabooAV-Installer/
 ./PeekabooAV-install.sh
 ```
 
 Or for testing most resent changes of the repository
 ```
-git clone https://github.com/scvenus/peekabooav-installer
-cd peekabooav-installer/
-git clone https://github.com/scvenus/peekabooav PeekabooAV
+git clone https://github.com/scVENUS/PeekabooAV-Installer
+cd PeekabooAV-Installer/
+git clone https://github.com/scVENUS/PeekabooAV
 ./PeekabooAV-install.sh
 ```
 
@@ -120,9 +120,9 @@ utils/checkFileWithPeekaboo.py grafana/Screenshot-2018-1-17\ Grafana\ -\ Peekabo
 ### This is what you type (copy - paste)
 
 ```
-git clone https://github.com/scvenus/peekabooav-installer
-cd peekabooav-installer/
-git clone https://github.com/scvenus/peekabooav PeekabooAV
+git clone https://github.com/scVENUS/PeekabooAV-Installer
+cd PeekabooAV-Installer/
+git clone https://github.com/scVENUS/PeekabooAV
 ```
 
 Then carry on reading [pipeline/README.md](pipeline/README.md)

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,6 +10,10 @@ cuckoo_api_token: "{{ lookup('password', 'cuckoo_api_token length=22 chars=ascii
 cortex_api_token: "{{ lookup('password', 'cortex_api_token length=22 chars=ascii_letters') }}"
 peekaboo_db_password: "{{ lookup('password', 'peekaboo_db_password length=15 chars=ascii_letters') }}"
 
+# limits Peekaboo version to latest point release of current minor release by
+# default
+peekaboo_pip_constraint: "<2.2"
+
 peekaboo_listen_address: "127.0.0.1"
 
 cuckoo_processors: 5

--- a/pstrap.sh
+++ b/pstrap.sh
@@ -13,6 +13,6 @@
 cd $(mktemp -d --suffix "-PeekabooAV-Installer")
 pwd
 
-git clone -b v2.0 https://github.com/scVENUS/PeekabooAV-Installer
+git clone -b v2.1 https://github.com/scVENUS/PeekabooAV-Installer
 cd PeekabooAV-Installer
 ./PeekabooAV-install.sh --quiet

--- a/pstrap.sh
+++ b/pstrap.sh
@@ -13,6 +13,6 @@
 cd $(mktemp -d --suffix "-PeekabooAV-Installer")
 pwd
 
-git clone -b v2.0 https://github.com/scvenus/peekabooav-installer
-cd peekabooav-installer
+git clone -b v2.0 https://github.com/scVENUS/PeekabooAV-Installer
+cd PeekabooAV-Installer
 ./PeekabooAV-install.sh --quiet

--- a/pstrap.sh
+++ b/pstrap.sh
@@ -13,6 +13,6 @@
 cd $(mktemp -d --suffix "-PeekabooAV-Installer")
 pwd
 
-git clone -b v2.0 --recurse-submodules https://github.com/scvenus/peekabooav-installer
+git clone -b v2.0 https://github.com/scvenus/peekabooav-installer
 cd peekabooav-installer
 ./PeekabooAV-install.sh --quiet


### PR DESCRIPTION
We should have an Installer release that matches the latest PeekabooAV release 2.1. So I went ahead and updated the docs and pstrap. While at it I improved consistency of repo references (to my mind at least) and fixed some typos.

What I'm wondering though: Even if we create a v2.1 tag, the installer will still install the latest PeekabooAV release from PyPI. (As does the v2.0 Installer release now there's a 2.1 on PyPI.)

Should we pin that as well, e.g. as `peekabooav<2.2`, so users always get the latest 2.1 point release? Or would we do matching point releases of the installer as well and pin to `peekabooav==2.1`?