### PR TITLE
k8s: Switch to our image repository

### DIFF
--- a/.github/workflows/publish-container-images-scheduled.yml
+++ b/.github/workflows/publish-container-images-scheduled.yml
@@ -130,6 +130,6 @@ jobs:
           ref: ${{ matrix.ref }}
           latest: ${{ matrix.latest }}
           latest-major: ${{ matrix.latest-major }}
-          image_name: michaelweiser/peekabooav-${{ matrix.image }}
+          image_name: scvenus/peekabooav-${{ matrix.image }}
           builddir: ${{ matrix.image }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-container-images.yml
+++ b/.github/workflows/publish-container-images.yml
@@ -37,6 +37,6 @@ jobs:
         with:
           ref: ${{ github.ref }}
           base-ref: ${{ github.base_ref }}
-          image_name: michaelweiser/peekabooav-${{ matrix.image }}
+          image_name: scvenus/peekabooav-${{ matrix.image }}
           builddir: ${{ matrix.image }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ version: "3"
 services:
   postfix-tx:
     # our latest tags point to the latest release version
-    image: ghcr.io/michaelweiser/peekabooav-postfix:edge
+    image: ghcr.io/scvenus/peekabooav-postfix:edge
     environment:
       - POSTFIX_MAIN_CF_MAILLOG_FILE=/dev/stdout
       - POSTFIX_MAIN_CF_INET_INTERFACES=all
@@ -51,7 +51,7 @@ services:
       retries: 3
       start_period: 30s
   cortex-setup:
-    image: ghcr.io/michaelweiser/peekabooav-cortex-setup:edge
+    image: ghcr.io/scvenus/peekabooav-cortex-setup:edge
     env_file:
       - compose.env
     depends_on:
@@ -93,7 +93,7 @@ services:
   # although if it is present, the peekaboo module does use it to cache data
   # for anything more than a showcase, please run a redis alongside rspamd
   rspamd:
-    image: ghcr.io/michaelweiser/peekabooav-rspamd:edge
+    image: ghcr.io/scvenus/peekabooav-rspamd:edge
     environment:
       RSPAMD_ENABLED_MODULES: "external_services force_actions"
 
@@ -146,7 +146,7 @@ services:
       retries: 5
       start_period: 10s
   postfix-rx:
-    image: ghcr.io/michaelweiser/peekabooav-postfix:edge
+    image: ghcr.io/scvenus/peekabooav-postfix:edge
     environment:
       - POSTFIX_MAIN_CF_MAILLOG_FILE=/dev/stdout
       - POSTFIX_MAIN_CF_INET_INTERFACES=all

--- a/k8s/helm-meta/peekabooav-pipeline/Chart.yaml
+++ b/k8s/helm-meta/peekabooav-pipeline/Chart.yaml
@@ -18,18 +18,18 @@ dependencies:
     repository: https://michaelweiser.github.io/helm-cortex/
   - name: cortex-setup
     version: 0.1.4
-    repository: https://michaelweiser.github.io/PeekabooAV-Installer/
+    repository: https://scvenus.github.io/PeekabooAV-Installer/
   - name: peekabooav
     version: 0.1.8
     repository: https://scvenus.github.io/PeekabooAV-Installer/
   - name: rspamd
     version: 0.1.5
-    repository: https://michaelweiser.github.io/PeekabooAV-Installer/
+    repository: https://scvenus.github.io/PeekabooAV-Installer/
   - name: postfix
     version: 0.1.4
-    repository: https://michaelweiser.github.io/PeekabooAV-Installer/
+    repository: https://scvenus.github.io/PeekabooAV-Installer/
     alias: postfix-tx
   - name: postfix
     version: 0.1.4
-    repository: https://michaelweiser.github.io/PeekabooAV-Installer/
+    repository: https://scvenus.github.io/PeekabooAV-Installer/
     alias: postfix-rx

--- a/k8s/helm-meta/peekabooav-pipeline/values.yaml
+++ b/k8s/helm-meta/peekabooav-pipeline/values.yaml
@@ -17,7 +17,7 @@ opensearch:
 
 cortex:
   image:
-    repository: michaelweiser/cortex
+    repository: scvenus/cortex
     tag: 3.1.4-1-k8s
   extraCortexConfigurations:
     basicauth.conf: |

--- a/k8s/helm/cortex-setup/values.yaml
+++ b/k8s/helm/cortex-setup/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: ghcr.io/michaelweiser/peekabooav-cortex-setup
+  repository: ghcr.io/scvenus/peekabooav-cortex-setup
   pullPolicy: IfNotPresent
   tag: ""
 

--- a/k8s/helm/postfix/values.yaml
+++ b/k8s/helm/postfix/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/michaelweiser/peekabooav-postfix
+  repository: ghcr.io/scvenus/peekabooav-postfix
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Switch helm charts as well as Github actions to our own repository now that k8s has been merged. This should successfully build and publish our container images.