### PR TITLE
ci: Bump custom action versions

### DIFF
--- a/.github/actions/container-image-publish/action.yml
+++ b/.github/actions/container-image-publish/action.yml
@@ -47,7 +47,7 @@ runs:
   using: composite
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # for scheduled builds, github.ref/$GITHUB_REF is always latest commit
         # on default branch
@@ -57,17 +57,17 @@ runs:
     # https://github.com/sigstore/cosign-installer
     - name: Install cosign
       if: inputs.event != 'pull_request'
-      uses: sigstore/cosign-installer@v3.0.5
+      uses: sigstore/cosign-installer@v3.7.0
 
     # Workaround: https://github.com/docker/build-push-action/issues/461
     - name: Setup Docker buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     # Login against a Docker registry except on PR
     # https://github.com/docker/login-action
     - name: Log into registry ${{ inputs.registry }}
       if: inputs.event != 'pull_request'
-      uses: docker/login-action@v2.0.0
+      uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry_username }}
@@ -128,7 +128,7 @@ runs:
     # https://github.com/docker/build-push-action
     - name: Build and push Docker image
       id: build-and-push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6.12.0
       with:
         context: ${{ inputs.builddir }}
         push: ${{ inputs.event != 'pull_request' }}


### PR DESCRIPTION
Bump the versions of our image publish custom action to make image signing work again.